### PR TITLE
chore(deps): update go toolchain version to `1.N.P`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cultureamp/terraform-provider-schema-registry
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/hashicorp/terraform-plugin-docs v0.19.4


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Use [1.N.P](https://go.dev/doc/toolchain#version) to resolve CodeQL issue:

> [!WARNING] 
> Invalid Go toolchain version [View file](https://github.com/cultureamp/terraform-provider-schema-registry/blob/main/go.mod#L1-L1)
>
>As of Go 1.21, toolchain versions [must use the 1.N.P syntax](https://go.dev/doc/toolchain#version).
>
>1.21 in go.mod does not match this syntax and there is no additional toolchain directive, which may cause some go commands to fail.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
